### PR TITLE
Bumping SD Card Formatter to version 5

### DIFF
--- a/sdformatter/sdformatter.nuspec
+++ b/sdformatter/sdformatter.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>sdformatter</id>
     <title>SD Formatter</title>
-    <version>4.0</version>
+    <version>5.0</version>
     <authors>SD Card Association</authors>
     <owners>sbussinger</owners>
     <description>This software from the SD Card Assocition formats all SD memory cards, SDHC memory cards and SDXC memory cards. SD Formatter provides quick and easy access to the full capabilities of your SD, SDHC and SDXC memory cards. The SD Formatter was created specifically for memory cards using the SD/SDHC/SDXC standards.</description>

--- a/sdformatter/tools/chocolateyInstall.ps1
+++ b/sdformatter/tools/chocolateyInstall.ps1
@@ -1,9 +1,9 @@
 $packageName = "sdformatter"
-$url = "https://www.sdcard.org/downloads/formatter_4/eula_windows/SDFormatterv4.zip"
+$url = "https://www.sdcard.org/downloads/formatter_4/eula_windows/SDCardFormatterv5_WinEN.zip"
 
 try {
   $scriptFolder = $(Split-Path -parent $MyInvocation.MyCommand.Definition)
-  $zipPath = Join-Path $scriptFolder "SDFormatterv4.zip"
+  $zipPath = Join-Path $scriptFolder "SDCardFormatterv5_WinEN.zip"
   $installerPath = Join-Path $scriptFolder "setup.exe"
 
   Get-ChocolateyWebFile "$packageName" "$zipPath" "$url"


### PR DESCRIPTION
The existing package is broken as version 4 of the utility has been removed from the sdcard.org website.
I have updated the package metadata and changed the source URL.

I wasn't sure how to test this locally but it _should_ work in its current state.